### PR TITLE
Option to filter Realms by locale

### DIFF
--- a/Explorers/Models/Realm.cs
+++ b/Explorers/Models/Realm.cs
@@ -53,8 +53,14 @@ namespace WowDotNetAPI.Models
         [DataMember(Name = "slug")]
         public string Slug { get; set; }
 
+        [DataMember(Name = "battlegroup")]
+        public string Battlegroup { get; set; }
+
+        [DataMember(Name = "locale")]
+        public string Locale { get; set; }
+
         public RealmType Type { get { return (RealmType)Enum.Parse(typeof(RealmType), type, true); } }
-        
+
         //See enum TODO comments
         //public RealmPopulation Population { get { return (RealmPopulation)Enum.Parse(typeof(RealmPopulation), population, true); } }
 

--- a/Explorers/WowExplorer.cs
+++ b/Explorers/WowExplorer.cs
@@ -180,12 +180,8 @@ namespace WowDotNetAPI
         public IEnumerable<Realm> GetRealms(Locale locale)
         {
             RealmsData realmsData;
-
-            //TryGetData<RealmsData>(
-            //    string.Format(@"{0}/wow/realm/status?locale={1}&apikey={2}", Host, Locale, APIKey),
-            //    out realmsData);
             TryGetData<RealmsData>(
-                string.Format(@"{0}/wow/realm/status?apikey={1}", Host, APIKey),
+                string.Format(@"{0}/wow/realm/status?locale={1}&apikey={2}", Host, Locale, APIKey),
                 out realmsData);
             if (realmsData == null)
             {

--- a/Explorers/WowExplorer.cs
+++ b/Explorers/WowExplorer.cs
@@ -177,15 +177,26 @@ namespace WowDotNetAPI
         #endregion
 
         #region Realms
-        public IEnumerable<Realm> GetRealms()
+        public IEnumerable<Realm> GetRealms(Locale locale)
         {
             RealmsData realmsData;
 
+            //TryGetData<RealmsData>(
+            //    string.Format(@"{0}/wow/realm/status?locale={1}&apikey={2}", Host, Locale, APIKey),
+            //    out realmsData);
             TryGetData<RealmsData>(
-                string.Format(@"{0}/wow/realm/status?locale={1}&apikey={2}", Host, Locale, APIKey),
+                string.Format(@"{0}/wow/realm/status?apikey={1}", Host, APIKey),
                 out realmsData);
+            if (realmsData == null)
+            {
+                return null;
+            }
+            return locale == Locale.None ? realmsData.Realms : realmsData.Realms.Where(x => x.Locale == locale.ToString());
+        }
 
-            return (realmsData != null) ? realmsData.Realms : null;
+        public IEnumerable<Realm> GetRealms()
+        {
+            return this.GetRealms(Locale.None);
         }
 
         #endregion
@@ -275,11 +286,11 @@ namespace WowDotNetAPI
         public IEnumerable<GuildRewardInfo> GetGuildRewards()
         {
             GuildRewardsData guildRewardsData;
-            
+
             TryGetData<GuildRewardsData>(
                 string.Format(@"{0}/wow/data/guild/rewards?locale={1}&apikey={2}", Host, Locale, APIKey),
                 out guildRewardsData);
-            
+
             return (guildRewardsData != null) ? guildRewardsData.Rewards : null;
         }
         #endregion
@@ -290,7 +301,7 @@ namespace WowDotNetAPI
             GuildPerksData guildPerksData;
 
             TryGetData<GuildPerksData>(
-                 string.Format(@"{0}/wow/data/guild/perks?locale={1}&apikey={2}", Host, Locale, APIKey), 
+                 string.Format(@"{0}/wow/data/guild/perks?locale={1}&apikey={2}", Host, Locale, APIKey),
                  out guildPerksData);
 
             return (guildPerksData != null) ? guildPerksData.Perks : null;
@@ -312,7 +323,7 @@ namespace WowDotNetAPI
         public IEnumerable<AchievementList> GetAchievements()
         {
             AchievementData achievementData;
-            
+
             TryGetData<AchievementData>(
                 string.Format(@"{0}/wow/data/character/achievements?locale={1}&apikey={2}", Host, Locale, APIKey),
                 out achievementData);
@@ -336,10 +347,10 @@ namespace WowDotNetAPI
         #region Battlegroups
         public IEnumerable<BattlegroupInfo> GetBattlegroupsData()
         {
-            BattlegroupData battlegroupData;            
-            
+            BattlegroupData battlegroupData;
+
             TryGetData<BattlegroupData>(
-                string.Format(@"{0}/wow/data/battlegroups/?locale={1}&apikey={2}", Host, Locale, APIKey), 
+                string.Format(@"{0}/wow/data/battlegroups/?locale={1}&apikey={2}", Host, Locale, APIKey),
                 out battlegroupData);
 
             return (battlegroupData != null) ? battlegroupData.Battlegroups : null;
@@ -352,7 +363,7 @@ namespace WowDotNetAPI
             Challenges challenges;
 
             TryGetData<Challenges>(
-                string.Format(@"{0}/wow/challenge/{1}?locale={2}&apikey={3}", Host, realm, Locale, APIKey), 
+                string.Format(@"{0}/wow/challenge/{1}?locale={2}&apikey={3}", Host, realm, Locale, APIKey),
                 out challenges);
 
             return challenges;
@@ -371,7 +382,7 @@ namespace WowDotNetAPI
                 requestedObject = JsonUtility.FromJSON<T>(url);
             }
             catch (Exception ex)
-            {                
+            {
                 requestedObject = null;
                 throw ex;
             }


### PR DESCRIPTION
Filtering realms by locale was not possible via ?locale=.
Testing the URL in the browser brought in all cases all realms.
Now the realms are filtered by an additional parameter. If it is set to
Locale.None all realms will be returned.

Also added Locale and Battlegroup property.